### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server for interacting with Workflowy. This server provides an MCP-compatible interface to Workflowy, allowing AI assistants to interact with your Workflowy lists programmatically.
 
+<a href="https://glama.ai/mcp/servers/@danield137/mcp-workflowy">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@danield137/mcp-workflowy/badge" alt="mcp-workflowy MCP server" />
+</a>
+
 ## What is MCP?
 
 The Model Context Protocol (MCP) is a standardized way for AI models to interact with external tools and APIs. This server implements MCP to allow AI assistants (like ChatGPT) to read and manipulate your Workflowy lists through a set of defined tools.
@@ -27,12 +31,10 @@ Giving my agent access to my notes, and my code base, the following are useful p
 - Node.js v18 or higher
 - A Workflowy account
 
-
 ### Quick Install
 
 ![NPM Version](https://img.shields.io/npm/v/mcp-workflowy)
 ![NPM Downloads](https://img.shields.io/npm/dm/mcp-workflowy)
-
 
 ```bash
 # Install the package globally


### PR DESCRIPTION
This PR adds a badge for the [mcp-workflowy](https://glama.ai/mcp/servers/@danield137/mcp-workflowy) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@danield137/mcp-workflowy">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@danield137/mcp-workflowy/badge" alt="mcp-workflowy MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.